### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         "sentry/sentry-laravel": "^4.3"
     },
     "require-dev": {
-        "brianium/paratest": "^7.5",
         "fakerphp/faker": "^1.23",
         "laravel/breeze": "^2.0",
         "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^8.0",
-        "phpunit/phpunit": "^10.5"
+        "nunomaduro/collision": "^7.0",
+        "pestphp/pest": "^2.2",
+        "pestphp/pest-plugin-laravel": "^2.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -1,107 +1,95 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Tv;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class ApiTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    /** @test */
-    public function we_can_create_a_new_entry_via_an_api_call(): void
-    {
-        $user = User::factory()->create();
-        $token = $user->createToken('test');
+test('we can create a new entry via an api call', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('test');
 
-        $result = $this->postJson(route('api.computer.update'), [
-            'computer_name' => 'TEST123',
-            'computer_id' => '12345',
-        ], [
-            'Authorization' => 'Bearer '.$token->plainTextToken,
-        ]);
+    $result = $this->postJson(route('api.computer.update'), [
+        'computer_name' => 'TEST123',
+        'computer_id' => '12345',
+    ], [
+        'Authorization' => 'Bearer '.$token->plainTextToken,
+    ]);
 
-        $result->assertOk();
-        tap(Tv::first(), function ($tv) {
-            $this->assertEquals('TEST123', $tv->computer_name);
-            $this->assertEquals('12345', $tv->computer_id);
-        });
-    }
+    $result->assertOk();
+    tap(Tv::first(), function ($tv) {
+        $this->assertEquals('TEST123', $tv->computer_name);
+        $this->assertEquals('12345', $tv->computer_id);
+    });
+});
 
-    /** @test */
-    public function we_can_update_an_exiting_entry_via_an_api_call(): void
-    {
-        $user = User::factory()->create();
-        $token = $user->createToken('test');
-        $tv = Tv::factory()->create([
-            'computer_name' => 'Jimmy',
-            'computer_id' => '98765',
-        ]);
+test('we can update an exiting entry via an api call', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('test');
+    $tv = Tv::factory()->create([
+        'computer_name' => 'Jimmy',
+        'computer_id' => '98765',
+    ]);
 
-        $result = $this->postJson(route('api.computer.update'), [
-            'computer_name' => 'Jimmy',
-            'computer_id' => '99999',
-        ], [
-            'Authorization' => 'Bearer '.$token->plainTextToken,
-        ]);
+    $result = $this->postJson(route('api.computer.update'), [
+        'computer_name' => 'Jimmy',
+        'computer_id' => '99999',
+    ], [
+        'Authorization' => 'Bearer '.$token->plainTextToken,
+    ]);
 
-        $result->assertOk();
-        tap(Tv::first(), function ($tv) {
-            $this->assertEquals('Jimmy', $tv->computer_name);
-            $this->assertEquals('99999', $tv->computer_id);
-        });
-    }
+    $result->assertOk();
+    tap(Tv::first(), function ($tv) {
+        $this->assertEquals('Jimmy', $tv->computer_name);
+        $this->assertEquals('99999', $tv->computer_id);
+    });
+});
 
-    /** @test */
-    public function the_computer_name_and_id_are_required_when_making_a_call(): void
-    {
-        $user = User::factory()->create();
-        $token = $user->createToken('test');
+test('the computer name and id are required when making a call', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('test');
 
-        $result = $this->postJson(route('api.computer.update'), [
-            'computer_name' => '',
-            'computer_id' => '',
-        ], [
-            'Authorization' => 'Bearer '.$token->plainTextToken,
-        ]);
+    $result = $this->postJson(route('api.computer.update'), [
+        'computer_name' => '',
+        'computer_id' => '',
+    ], [
+        'Authorization' => 'Bearer '.$token->plainTextToken,
+    ]);
 
-        $result->assertStatus(422);
-        $result->assertJson([
-            'message' => 'The computer name field is required. (and 1 more error)',
-            'errors' => [
-                'computer_name' => ['The computer name field is required.'],
-                'computer_id' => ['The computer id field is required.'],
-            ],
-        ]);
-        $this->assertEquals(0, Tv::count());
-    }
+    $result->assertStatus(422);
+    $result->assertJson([
+        'message' => 'The computer name field is required. (and 1 more error)',
+        'errors' => [
+            'computer_name' => ['The computer name field is required.'],
+            'computer_id' => ['The computer id field is required.'],
+        ],
+    ]);
+    $this->assertEquals(0, Tv::count());
+});
 
-    /** @test */
-    public function the_bearer_token_header_is_required_and_must_be_valid(): void
-    {
-        $user = User::factory()->create();
-        $token = $user->createToken('test');
+test('the bearer token header is required and must be valid', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('test');
 
-        $result = $this->postJson(route('api.computer.update'), [
-            'computer_name' => 'fred',
-            'computer_id' => '12345',
-        ], [
-        ]);
+    $result = $this->postJson(route('api.computer.update'), [
+        'computer_name' => 'fred',
+        'computer_id' => '12345',
+    ], [
+    ]);
 
-        $result->assertUnauthorized();
-        $this->assertEquals(0, Tv::count());
+    $result->assertUnauthorized();
+    $this->assertEquals(0, Tv::count());
 
-        $result = $this->postJson(route('api.computer.update'), [
-            'computer_name' => 'fred',
-            'computer_id' => '12345',
-        ], [
-            'Authorization' => 'Bearer '.'not-a-valid-token',
-        ]);
+    $result = $this->postJson(route('api.computer.update'), [
+        'computer_name' => 'fred',
+        'computer_id' => '12345',
+    ], [
+        'Authorization' => 'Bearer '.'not-a-valid-token',
+    ]);
 
-        $result->assertUnauthorized();
-        $this->assertEquals(0, Tv::count());
-    }
-}
+    $result->assertUnauthorized();
+    $this->assertEquals(0, Tv::count());
+});

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -21,8 +21,8 @@ test('we can create a new entry via an api call', function () {
 
     $result->assertOk();
     tap(Tv::first(), function ($tv) {
-        $this->assertEquals('TEST123', $tv->computer_name);
-        $this->assertEquals('12345', $tv->computer_id);
+        expect($tv->computer_name)->toEqual('TEST123');
+        expect($tv->computer_id)->toEqual('12345');
     });
 });
 
@@ -43,8 +43,8 @@ test('we can update an exiting entry via an api call', function () {
 
     $result->assertOk();
     tap(Tv::first(), function ($tv) {
-        $this->assertEquals('Jimmy', $tv->computer_name);
-        $this->assertEquals('99999', $tv->computer_id);
+        expect($tv->computer_name)->toEqual('Jimmy');
+        expect($tv->computer_id)->toEqual('99999');
     });
 });
 
@@ -67,7 +67,7 @@ test('the computer name and id are required when making a call', function () {
             'computer_id' => ['The computer id field is required.'],
         ],
     ]);
-    $this->assertEquals(0, Tv::count());
+    expect(Tv::count())->toEqual(0);
 });
 
 test('the bearer token header is required and must be valid', function () {
@@ -81,7 +81,7 @@ test('the bearer token header is required and must be valid', function () {
     ]);
 
     $result->assertUnauthorized();
-    $this->assertEquals(0, Tv::count());
+    expect(Tv::count())->toEqual(0);
 
     $result = $this->postJson(route('api.computer.update'), [
         'computer_name' => 'fred',
@@ -91,5 +91,5 @@ test('the bearer token header is required and must be valid', function () {
     ]);
 
     $result->assertUnauthorized();
-    $this->assertEquals(0, Tv::count());
+    expect(Tv::count())->toEqual(0);
 });

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -2,9 +2,6 @@
 
 use App\Models\Tv;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
 
 test('we can create a new entry via an api call', function () {
     $user = User::factory()->create();

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -5,8 +5,6 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('we can create a new entry via an api call', function () {
     $user = User::factory()->create();

--- a/tests/Feature/UiTest.php
+++ b/tests/Feature/UiTest.php
@@ -6,8 +6,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('unauthenticated users are redirected to the login page', function () {
     $response = $this->get(route('home'));

--- a/tests/Feature/UiTest.php
+++ b/tests/Feature/UiTest.php
@@ -64,13 +64,13 @@ test('authenticated users can see the list of existing api keys', function () {
 test('authenticated users can generate a new api key', function () {
     $user = User::factory()->create();
 
-    $this->assertEquals(0, $user->tokens()->count());
+    expect($user->tokens()->count())->toEqual(0);
 
     Livewire::actingAs($user)->test('api-token-generator')
         ->set('tokenName', 'hello')
         ->call('generate');
 
-    $this->assertEquals(1, $user->tokens()->count());
+    expect($user->tokens()->count())->toEqual(1);
 });
 
 test('authenticated users can revoke an existing api key', function () {
@@ -78,11 +78,11 @@ test('authenticated users can revoke an existing api key', function () {
     $token1 = $user->createToken('first');
     $token2 = $user->createToken('second');
 
-    $this->assertEquals(2, $user->tokens()->count());
+    expect($user->tokens()->count())->toEqual(2);
 
     Livewire::actingAs($user)->test('api-keys')
         ->call('revoke', $user->tokens->last()->id); // revoke 'second' api key
 
-    $this->assertEquals(1, $user->tokens()->count());
+    expect($user->tokens()->count())->toEqual(1);
     $this->assertTrue($user->fresh()->tokens->contains(fn ($token) => $token->name == 'first'));
 });

--- a/tests/Feature/UiTest.php
+++ b/tests/Feature/UiTest.php
@@ -2,10 +2,7 @@
 
 use App\Models\Tv;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
-use Tests\TestCase;
-
 
 test('unauthenticated users are redirected to the login page', function () {
     $response = $this->get(route('home'));

--- a/tests/Feature/UiTest.php
+++ b/tests/Feature/UiTest.php
@@ -1,104 +1,88 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Tv;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class UiTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    /** @test */
-    public function unauthenticated_users_are_redirected_to_the_login_page(): void
-    {
-        $response = $this->get(route('home'));
+test('unauthenticated users are redirected to the login page', function () {
+    $response = $this->get(route('home'));
 
-        $response->assertRedirect(route('login'));
-    }
+    $response->assertRedirect(route('login'));
+});
 
-    /** @test */
-    public function authenticated_users_can_see_the_list_of_computers(): void
-    {
-        $user = User::factory()->create();
-        $tv1 = Tv::factory()->create();
-        $tv2 = Tv::factory()->create();
+test('authenticated users can see the list of computers', function () {
+    $user = User::factory()->create();
+    $tv1 = Tv::factory()->create();
+    $tv2 = Tv::factory()->create();
 
-        $response = $this->actingAs($user)->get(route('home'));
+    $response = $this->actingAs($user)->get(route('home'));
 
-        $response->assertOk();
-        $response->assertSeeLivewire('computer-list');
-        $response->assertSee($tv1->computer_name);
-        $response->assertSee($tv1->computer_id);
-        $response->assertSee($tv2->computer_name);
-        $response->assertSee($tv2->computer_id);
-    }
+    $response->assertOk();
+    $response->assertSeeLivewire('computer-list');
+    $response->assertSee($tv1->computer_name);
+    $response->assertSee($tv1->computer_id);
+    $response->assertSee($tv2->computer_name);
+    $response->assertSee($tv2->computer_id);
+});
 
-    /** @test */
-    public function we_can_search_for_a_specific_computer_by_id_or_name(): void
-    {
-        $user = User::factory()->create();
-        $tv1 = Tv::factory()->create(['computer_name' => 'fred', 'computer_id' => '99999']);
-        $tv2 = Tv::factory()->create(['computer_name' => 'ginger', 'computer_id' => '55555']);
+test('we can search for a specific computer by id or name', function () {
+    $user = User::factory()->create();
+    $tv1 = Tv::factory()->create(['computer_name' => 'fred', 'computer_id' => '99999']);
+    $tv2 = Tv::factory()->create(['computer_name' => 'ginger', 'computer_id' => '55555']);
 
-        Livewire::actingAs($user)->test('computer-list')
-            ->assertSee('fred')
-            ->assertSee('ginger')
-            ->set('searchTerm', 'fred')
-            ->assertSee('fred')
-            ->assertDontSee('ginger')
-            ->set('searchTerm', '55555')
-            ->assertDontSee('fred')
-            ->assertSee('ginger');
-    }
+    Livewire::actingAs($user)->test('computer-list')
+        ->assertSee('fred')
+        ->assertSee('ginger')
+        ->set('searchTerm', 'fred')
+        ->assertSee('fred')
+        ->assertDontSee('ginger')
+        ->set('searchTerm', '55555')
+        ->assertDontSee('fred')
+        ->assertSee('ginger');
+});
 
-    /** @test */
-    public function authenticated_users_can_see_the_list_of_existing_api_keys(): void
-    {
-        $user1 = User::factory()->create();
-        $user2 = User::factory()->create();
-        $token1 = $user1->createToken('hello kitty');
-        $token2 = $user2->createToken('miffy');
+test('authenticated users can see the list of existing api keys', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+    $token1 = $user1->createToken('hello kitty');
+    $token2 = $user2->createToken('miffy');
 
-        $response = $this->actingAs($user1)->get(route('apikeys'));
+    $response = $this->actingAs($user1)->get(route('apikeys'));
 
-        $response->assertOk();
-        $response->assertSeeLivewire('api-keys');
-        $response->assertSeeLivewire('api-token-generator');
-        $response->assertSee('hello kitty');
-        $response->assertSee('miffy');
-    }
+    $response->assertOk();
+    $response->assertSeeLivewire('api-keys');
+    $response->assertSeeLivewire('api-token-generator');
+    $response->assertSee('hello kitty');
+    $response->assertSee('miffy');
+});
 
-    /** @test */
-    public function authenticated_users_can_generate_a_new_api_key(): void
-    {
-        $user = User::factory()->create();
+test('authenticated users can generate a new api key', function () {
+    $user = User::factory()->create();
 
-        $this->assertEquals(0, $user->tokens()->count());
+    $this->assertEquals(0, $user->tokens()->count());
 
-        Livewire::actingAs($user)->test('api-token-generator')
-            ->set('tokenName', 'hello')
-            ->call('generate');
+    Livewire::actingAs($user)->test('api-token-generator')
+        ->set('tokenName', 'hello')
+        ->call('generate');
 
-        $this->assertEquals(1, $user->tokens()->count());
-    }
+    $this->assertEquals(1, $user->tokens()->count());
+});
 
-    /** @test */
-    public function authenticated_users_can_revoke_an_existing_api_key(): void
-    {
-        $user = User::factory()->create();
-        $token1 = $user->createToken('first');
-        $token2 = $user->createToken('second');
+test('authenticated users can revoke an existing api key', function () {
+    $user = User::factory()->create();
+    $token1 = $user->createToken('first');
+    $token2 = $user->createToken('second');
 
-        $this->assertEquals(2, $user->tokens()->count());
+    $this->assertEquals(2, $user->tokens()->count());
 
-        Livewire::actingAs($user)->test('api-keys')
-            ->call('revoke', $user->tokens->last()->id); // revoke 'second' api key
+    Livewire::actingAs($user)->test('api-keys')
+        ->call('revoke', $user->tokens->last()->id); // revoke 'second' api key
 
-        $this->assertEquals(1, $user->tokens()->count());
-        $this->assertTrue($user->fresh()->tokens->contains(fn ($token) => $token->name == 'first'));
-    }
-}
+    $this->assertEquals(1, $user->tokens()->count());
+    $this->assertTrue($user->fresh()->tokens->contains(fn ($token) => $token->name == 'first'));
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/configuring-tests */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/custom-helpers */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php
 
+uses(\Tests\TestCase::class)->in('Feature', 'Unit');
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class)->in('Feature', 'Unit');
+
 /*
 |--------------------------------------------------------------------------
 | Test Case


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-139709` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
